### PR TITLE
Decrease reference count of object created with PyList_New.

### DIFF
--- a/src/interventions_utils.i
+++ b/src/interventions_utils.i
@@ -98,6 +98,7 @@ PyObject * get_contacts(model * model)
                                         PyList_SetItem(it, 3, PyInt_FromLong(inter->type));
                                         PyList_Append(out, it);
                                         inter = inter->next;
+                                        Py_DECREF(it);
                                 }
                         }
                 }
@@ -130,6 +131,7 @@ PyObject * get_contacts_daily(model * model, int day)
                                 PyList_SetItem(it, 3, PyInt_FromLong(inter->type));
                                 PyList_Append(out, it);
                                 inter = inter->next;
+                                Py_DECREF(it);
                         }
                 }
         }


### PR DESCRIPTION
Dear Aleingrosso,

I suspect there is a memory leak in intervention_utils.i. The Python list `it` is put on the heap with `PyList_New,` but the reference count is not decremented accordingly. 
[openabm_swig_memory_issues (1).pdf](https://github.com/aleingrosso/OpenABM-Covid19/files/14864799/openabm_swig_memory_issues.1.pdf)

In the attachment, I include memory usage of the simulator before and after this change. About two years ago, I discussed this with @abraunst. This week, the results were independently confirmed by @martentyrk.

Thank you in advance for considering this pull request,
Rob

